### PR TITLE
Converts existing assertions to AssertJ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <curator-version>2.6.0</curator-version>
         <jackson-version>2.4.2</jackson-version>
         <testng-version>6.8.8</testng-version>
+        <assertj-version>3.0.0</assertj-version>
         <slf4j-version>1.7.7</slf4j-version>
         <jgrapht-version>0.9.0</jgrapht-version>
 
@@ -145,6 +146,13 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${testng-version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/com/nirmata/workflow/BaseForTests.java
+++ b/src/test/java/com/nirmata/workflow/BaseForTests.java
@@ -19,18 +19,24 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.TestingServer;
+import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import java.util.concurrent.BlockingQueue;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public abstract class BaseForTests
 {
+    protected Timing timing;
     protected TestingServer server;
     protected CuratorFramework curator;
 
     @BeforeMethod
     public void setup() throws Exception
     {
+        timing = new Timing();
         server = new TestingServer();
 
         curator = CuratorFrameworkFactory.builder().connectString(server.getConnectString()).retryPolicy(new RetryOneTime(1)).build();
@@ -42,5 +48,10 @@ public abstract class BaseForTests
     {
         CloseableUtils.closeQuietly(curator);
         CloseableUtils.closeQuietly(server);
+    }
+
+    protected <T> T poll(BlockingQueue<T> queue) throws InterruptedException
+    {
+        return queue.poll(timing.milliseconds(), MILLISECONDS);
     }
 }

--- a/src/test/java/com/nirmata/workflow/ConcurrentTaskChecker.java
+++ b/src/test/java/com/nirmata/workflow/ConcurrentTaskChecker.java
@@ -15,28 +15,23 @@
  */
 package com.nirmata.workflow;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.LinkedHashMultiset;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
 import com.nirmata.workflow.models.TaskId;
-import org.testng.Assert;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 class ConcurrentTaskChecker
 {
-    private final Set<TaskId> currentSet = Sets.newHashSet();
-    private final List<TaskId> all = Lists.newArrayList();
+    private final Set<TaskId> currentSet = Sets.newLinkedHashSet();
+    private final Multiset<TaskId> all = LinkedHashMultiset.create();
     private int count = 0;
     private final List<Set<TaskId>> sets = Lists.newArrayList();
-
-    synchronized void reset()
-    {
-        currentSet.clear();
-        all.clear();
-        sets.clear();
-        count = 0;
-    }
 
     synchronized void add(TaskId taskId)
     {
@@ -49,25 +44,17 @@ class ConcurrentTaskChecker
     {
         if ( --count == 0 )
         {
-            HashSet<TaskId> copy = Sets.newHashSet(currentSet);
+            Set<TaskId> copy = ImmutableSet.copyOf(currentSet);
             currentSet.clear();
             count = 0;
             sets.add(copy);
         }
     }
 
-    synchronized List<Set<TaskId>> getSets()
+    synchronized ConcurrentTaskChecker assertTasksSetsContainOnly(Set<TaskId>... expected)
     {
-        return Lists.newArrayList(sets);
-    }
-
-    synchronized List<TaskId> getAll()
-    {
-        return Lists.newArrayList(all);
-    }
-
-    synchronized void assertNoDuplicates()
-    {
-        Assert.assertEquals(all.size(), Sets.newHashSet(all).size());   // no dups
+        assertThat(all.size()).isEqualTo(all.elementSet().size()); // no dups
+        assertThat(sets).containsOnly(expected);
+        return this;
     }
 }

--- a/src/test/java/com/nirmata/workflow/TestAutoCleanerHolder.java
+++ b/src/test/java/com/nirmata/workflow/TestAutoCleanerHolder.java
@@ -25,7 +25,6 @@ import com.nirmata.workflow.details.AutoCleanerHolder;
 import com.nirmata.workflow.models.RunId;
 import com.nirmata.workflow.models.TaskId;
 import org.apache.curator.test.Timing;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 import java.time.Clock;
 import java.time.Duration;
@@ -34,29 +33,30 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class TestAutoCleanerHolder
 {
     @Test
     public void testNull() throws InterruptedException
     {
         Timing timing = new Timing();
-        AutoCleanerHolder holder = new AutoCleanerHolder(null, Duration.ofDays(10));
-        Assert.assertFalse(holder.shouldRun());
-        Assert.assertFalse(holder.shouldRun());
-        timing.sleepABit();
-        Assert.assertFalse(holder.shouldRun());
-        Assert.assertFalse(holder.shouldRun());
 
-        Assert.assertNotNull(holder.getRunPeriod());
+        AutoCleanerHolder holder = new AutoCleanerHolder(null, Duration.ofDays(10));
+        assertThat(holder.shouldRun()).isFalse();
+        timing.sleepABit();
+        assertThat(holder.shouldRun()).isFalse();
+
+        assertThat(holder.getRunPeriod()).isGreaterThan(Duration.ZERO);
     }
 
     @Test
     public void testPeriod() throws InterruptedException
     {
         AutoCleanerHolder holder = new AutoCleanerHolder(new StandardAutoCleaner(Duration.ofSeconds(2)), Duration.ofSeconds(1));
-        Assert.assertFalse(holder.shouldRun());
+        assertThat(holder.shouldRun()).isFalse();
         TimeUnit.SECONDS.sleep(2);
-        Assert.assertTrue(holder.shouldRun());
+        assertThat(holder.shouldRun()).isTrue();
 
         RunId runningId = new RunId();
         RunId completedId = new RunId();
@@ -103,7 +103,6 @@ public class TestAutoCleanerHolder
         };
 
         holder.run(admin);
-        Assert.assertEquals(cleaned.size(), 1);
-        Assert.assertEquals(cleaned.get(0), completedId);
+        assertThat(cleaned).containsOnly(completedId);
     }
 }

--- a/src/test/java/com/nirmata/workflow/TestTaskExecutor.java
+++ b/src/test/java/com/nirmata/workflow/TestTaskExecutor.java
@@ -25,34 +25,11 @@ import java.util.concurrent.CountDownLatch;
 
 public class TestTaskExecutor implements TaskExecutor
 {
-    private final ConcurrentTaskChecker checker = new ConcurrentTaskChecker();
-    private final int latchQty;
-    private volatile CountDownLatch latch;
-
-    public TestTaskExecutor()
-    {
-        this(1);
-    }
+    final ConcurrentTaskChecker checker = new ConcurrentTaskChecker();
+    final CountDownLatch latch;
 
     public TestTaskExecutor(int latchQty)
     {
-        this.latchQty = latchQty;
-        latch = new CountDownLatch(latchQty);
-    }
-
-    public CountDownLatch getLatch()
-    {
-        return latch;
-    }
-
-    public ConcurrentTaskChecker getChecker()
-    {
-        return checker;
-    }
-
-    public void reset()
-    {
-        checker.reset();
         latch = new CountDownLatch(latchQty);
     }
 

--- a/src/test/java/com/nirmata/workflow/WorkflowAssertions.java
+++ b/src/test/java/com/nirmata/workflow/WorkflowAssertions.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2014 Nirmata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nirmata.workflow;
+
+import com.nirmata.workflow.admin.RunInfo;
+import com.nirmata.workflow.admin.TaskDetails;
+import com.nirmata.workflow.admin.TaskInfo;
+import com.nirmata.workflow.models.Task;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.internal.Maps;
+import org.assertj.core.internal.Objects;
+
+import static org.assertj.core.util.Arrays.array;
+
+public class WorkflowAssertions extends Assertions
+{
+    static final Objects objects = Objects.instance();
+    static final Maps maps = Maps.instance();
+
+    public static RunInfoAssert assertThat(RunInfo actual)
+    {
+        return new RunInfoAssert(actual);
+    }
+
+    public static final class RunInfoAssert extends AbstractAssert<RunInfoAssert, RunInfo>
+    {
+
+        RunInfoAssert(RunInfo actual)
+        {
+            super(actual, RunInfoAssert.class);
+        }
+
+        public RunInfoAssert isComplete()
+        {
+            isNotNull();
+            if (!actual.isComplete()) {
+                failWithMessage("\nExpecting <%s> to be complete", actual);
+            }
+            return myself;
+        }
+
+        public RunInfoAssert isNotComplete()
+        {
+            isNotNull();
+            if (actual.isComplete()) {
+                failWithMessage("\nExpecting <%s> to not be complete", actual);
+            }
+            return myself;
+        }
+    }
+
+    public static TaskDetailsAssert assertThat(TaskDetails actual)
+    {
+        return new TaskDetailsAssert(actual);
+    }
+
+    public static final class TaskDetailsAssert extends AbstractAssert<TaskDetailsAssert, TaskDetails>
+    {
+        TaskDetailsAssert(TaskDetails actual)
+        {
+            super(actual, TaskDetailsAssert.class);
+        }
+
+        public TaskDetailsAssert matchesTask(Task expected)
+        {
+            isNotNull();
+            objects.assertEqual(info, actual.getTaskId(), expected.getTaskId());
+            if (expected.isExecutable()) {
+                objects.assertEqual(info, actual.getTaskType(), expected.getTaskType());
+            }
+            objects.assertEqual(info, actual.getMetaData(), expected.getMetaData());
+            return this;
+        }
+    }
+
+    public static TaskInfoAssert assertThat(TaskInfo actual)
+    {
+        return new TaskInfoAssert(actual);
+    }
+
+    public static final class TaskInfoAssert extends AbstractAssert<TaskInfoAssert, TaskInfo>
+    {
+
+        TaskInfoAssert(TaskInfo actual)
+        {
+            super(actual, TaskInfoAssert.class);
+        }
+
+        public TaskInfoAssert hasNotStarted()
+        {
+            isNotNull();
+            if (actual.hasStarted()) {
+                failWithMessage("\nExpecting <%s> to not have started", actual);
+            }
+            return myself;
+        }
+
+        public TaskInfoAssert isComplete()
+        {
+            isNotNull();
+            if (!actual.hasStarted() || !actual.isComplete()) {
+                failWithMessage("\nExpecting <%s> to be complete", actual);
+            }
+            maps.assertContains(info, actual.getResult().getResultData(), array(entry("taskId", actual.getTaskId().getId())));
+            return myself;
+        }
+
+        public TaskInfoAssert isNotComplete()
+        {
+            isNotNull();
+            if (!actual.hasStarted()) {
+                failWithMessage("\nExpecting <%s> to have started", actual);
+            }
+            if (actual.isComplete()) {
+                failWithMessage("\nExpecting <%s> to not be complete", actual);
+            }
+            return myself;
+        }
+    }
+}

--- a/src/test/java/com/nirmata/workflow/serialization/TestSerializer.java
+++ b/src/test/java/com/nirmata/workflow/serialization/TestSerializer.java
@@ -29,7 +29,6 @@ import com.nirmata.workflow.models.Task;
 import com.nirmata.workflow.models.TaskExecutionResult;
 import com.nirmata.workflow.models.TaskId;
 import com.nirmata.workflow.models.TaskType;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -44,6 +43,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.nirmata.workflow.serialization.JsonSerializer.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSerializer
 {
@@ -58,7 +58,7 @@ public class TestSerializer
         System.out.println(str);
 
         RunnableTaskDag unRunnableTaskDag = getRunnableTaskDag(fromString(str));
-        Assert.assertEquals(runnableTaskDag, unRunnableTaskDag);
+        assertThat(runnableTaskDag).isEqualTo(unRunnableTaskDag);
     }
 
     @Test
@@ -70,7 +70,7 @@ public class TestSerializer
         System.out.println(str);
 
         ExecutableTask unExecutableTask = getExecutableTask(fromString(str));
-        Assert.assertEquals(executableTask, unExecutableTask);
+        assertThat(executableTask).isEqualTo(unExecutableTask);
     }
 
     @Test
@@ -78,12 +78,10 @@ public class TestSerializer
     {
         Map<TaskId, ExecutableTask> tasks = Stream.generate(() -> "")
             .limit(random.nextInt(3) + 1)
-            .collect(Collectors.toMap(s -> new TaskId(), s -> new ExecutableTask(new RunId(), new TaskId(), randomTaskType(), randomMap(), random.nextBoolean())))
-            ;
+            .collect(Collectors.toMap(s -> new TaskId(), s -> new ExecutableTask(new RunId(), new TaskId(), randomTaskType(), randomMap(), random.nextBoolean())));
         List<RunnableTaskDag> taskDags = Stream.generate(() -> new RunnableTaskDag(new TaskId(), randomTasks()))
             .limit(random.nextInt(3) + 1)
-            .collect(Collectors.toList())
-            ;
+            .collect(Collectors.toList());
         LocalDateTime completionTime = random.nextBoolean() ? LocalDateTime.now() : null;
         RunId parentRunId = random.nextBoolean() ? new RunId() : null;
         RunnableTask runnableTask = new RunnableTask(tasks, taskDags, LocalDateTime.now(), completionTime, parentRunId);
@@ -92,7 +90,7 @@ public class TestSerializer
         System.out.println(str);
 
         RunnableTask unRunnableTask = getRunnableTask(fromString(str));
-        Assert.assertEquals(runnableTask, unRunnableTask);
+        assertThat(runnableTask).isEqualTo(unRunnableTask);
     }
 
     @Test
@@ -104,7 +102,7 @@ public class TestSerializer
         System.out.println(str);
 
         TaskExecutionResult unTaskExecutionResult = getTaskExecutionResult(fromString(str));
-        Assert.assertEquals(taskExecutionResult, unTaskExecutionResult);
+        assertThat(taskExecutionResult).isEqualTo(unTaskExecutionResult);
     }
 
     @Test
@@ -116,7 +114,7 @@ public class TestSerializer
         System.out.println(str);
 
         StartedTask unStartedTask = getStartedTask(fromString(str));
-        Assert.assertEquals(startedTask, unStartedTask);
+        assertThat(startedTask).isEqualTo(unStartedTask);
     }
 
     @Test
@@ -128,7 +126,7 @@ public class TestSerializer
         System.out.println(str);
 
         TaskType unTaskType = getTaskType(fromString(str));
-        Assert.assertEquals(taskType, unTaskType);
+        assertThat(taskType).isEqualTo(unTaskType);
     }
 
     @Test
@@ -140,7 +138,7 @@ public class TestSerializer
         System.out.println(str);
 
         Task unTask = getTask(fromString(str));
-        Assert.assertEquals(task, unTask);
+        assertThat(task).isEqualTo(unTask);
     }
 
     @Test
@@ -156,9 +154,8 @@ public class TestSerializer
         Task task = new Task(new TaskId("root"), Lists.newArrayList(task1, task2));
 
         String json = Resources.toString(Resources.getResource("tasks.json"), Charset.defaultCharset());
-        Task unTask = getTask(fromString(json));
-
-        Assert.assertEquals(task, unTask);
+        Task untask = getTask(fromString(json));
+        assertThat(task).isEqualTo(untask);
     }
 
     @Test
@@ -171,7 +168,7 @@ public class TestSerializer
         System.out.println(str);
 
         Task unTask = mapper.get(fromString(str), Task.class);
-        Assert.assertEquals(task, unTask);
+        assertThat(task).isEqualTo(unTask);
     }
 
     @Test
@@ -182,7 +179,7 @@ public class TestSerializer
         StartedTask startedTask = new StartedTask(Integer.toString(random.nextInt()), LocalDateTime.now(Clock.systemUTC()));
         byte[] bytes = serializer.serialize(startedTask);
         StartedTask unStartedTask = serializer.deserialize(bytes, StartedTask.class);
-        Assert.assertEquals(startedTask, unStartedTask);
+        assertThat(startedTask).isEqualTo(unStartedTask);
     }
 
     private Task randomTask(int index)


### PR DESCRIPTION
Converts existing assertions to AssertJ
    
Formerly, assertions were written using TestNG. This converts them to AssertJ.
There are a number of benefits, but these are my top 2:
    
 * AssertJ makes assertions on collections far more coherent.
 * AssertJ has built-in support for Java 8 and can make failures more expressive.
