### PR TITLE
Backports main code to Java 7/Joda

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,9 @@
         <testng-version>6.8.8</testng-version>
         <slf4j-version>1.7.7</slf4j-version>
         <jgrapht-version>0.9.0</jgrapht-version>
+        <joda-version>2.7</joda-version>
 
+        <animal-sniffer-maven-plugin-version>1.14</animal-sniffer-maven-plugin-version>
         <maven-compiler-plugin-version>3.1</maven-compiler-plugin-version>
         <maven-site-plugin-version>3.4</maven-site-plugin-version>
         <maven-project-info-reports-plugin-version>2.7</maven-project-info-reports-plugin-version>
@@ -142,6 +144,12 @@
         </dependency>
 
         <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>${joda-version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${testng-version}</version>
@@ -209,6 +217,19 @@
                     <source>${jdk-version}</source>
                     <target>${jdk-version}</target>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <source>1.7</source>
+                            <target>1.7</target>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
@@ -302,6 +323,26 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>${maven-deploy-plugin-version}</version>
+            </plugin>
+            <!-- Make sure Java 8 classes and methods aren't accidentally used -->
+            <plugin>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>${animal-sniffer-maven-plugin-version}</version>
+                <configuration>
+                    <signature>
+                        <groupId>org.codehaus.mojo.signature</groupId>
+                        <artifactId>java17</artifactId>
+                        <version>1.0</version>
+                    </signature>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/nirmata/workflow/WorkflowManager.java
+++ b/src/main/java/com/nirmata/workflow/WorkflowManager.java
@@ -24,7 +24,6 @@ import com.nirmata.workflow.models.TaskExecutionResult;
 import com.nirmata.workflow.models.TaskId;
 import org.apache.curator.framework.CuratorFramework;
 import java.io.Closeable;
-import java.util.Optional;
 
 /**
  * Main API - create via {@link WorkflowManagerBuilder}
@@ -89,9 +88,9 @@ public interface WorkflowManager extends Closeable
      *
      * @param runId the run
      * @param taskId the task
-     * @return if found, a loaded optional with the result. Otherwise, an empty optional.
+     * @return if found, a loaded optional with the result. Otherwise, null.
      */
-    public Optional<TaskExecutionResult> getTaskExecutionResult(RunId runId, TaskId taskId);
+    public TaskExecutionResult getTaskExecutionResult(RunId runId, TaskId taskId);
 
     /**
      * Return administration operations

--- a/src/main/java/com/nirmata/workflow/WorkflowManagerBuilder.java
+++ b/src/main/java/com/nirmata/workflow/WorkflowManagerBuilder.java
@@ -28,9 +28,9 @@ import com.nirmata.workflow.queue.zookeeper.ZooKeeperQueueFactory;
 import com.nirmata.workflow.serialization.Serializer;
 import com.nirmata.workflow.serialization.StandardSerializer;
 import org.apache.curator.framework.CuratorFramework;
+import org.joda.time.Duration;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.time.Duration;
 import java.util.List;
 
 /**
@@ -196,6 +196,6 @@ public class WorkflowManagerBuilder
 
     private AutoCleanerHolder newNullHolder()
     {
-        return new AutoCleanerHolder(null, Duration.ofDays(Integer.MAX_VALUE));
+        return new AutoCleanerHolder(null, Duration.standardDays(Integer.MAX_VALUE));
     }
 }

--- a/src/main/java/com/nirmata/workflow/admin/AutoCleaner.java
+++ b/src/main/java/com/nirmata/workflow/admin/AutoCleaner.java
@@ -15,7 +15,6 @@
  */
 package com.nirmata.workflow.admin;
 
-@FunctionalInterface
 public interface AutoCleaner
 {
     /**

--- a/src/main/java/com/nirmata/workflow/admin/RunInfo.java
+++ b/src/main/java/com/nirmata/workflow/admin/RunInfo.java
@@ -17,8 +17,7 @@ package com.nirmata.workflow.admin;
 
 import com.google.common.base.Preconditions;
 import com.nirmata.workflow.models.RunId;
-import java.time.LocalDateTime;
-import java.util.Optional;
+import org.joda.time.LocalDateTime;
 
 /**
  * Run information
@@ -27,7 +26,7 @@ public class RunInfo
 {
     private final RunId runId;
     private final LocalDateTime startTimeUtc;
-    private final Optional<LocalDateTime> completionTimeUtc;
+    private final LocalDateTime completionTimeUtc;
 
     public RunInfo(RunId runId, LocalDateTime startTimeUtc)
     {
@@ -38,7 +37,7 @@ public class RunInfo
     {
         this.runId = Preconditions.checkNotNull(runId, "runId cannot be null");
         this.startTimeUtc = Preconditions.checkNotNull(startTimeUtc, "startTimeUtc cannot be null");
-        this.completionTimeUtc = Optional.ofNullable(completionTimeUtc);
+        this.completionTimeUtc = completionTimeUtc;
     }
 
     public RunId getRunId()
@@ -51,14 +50,17 @@ public class RunInfo
         return startTimeUtc;
     }
 
+    /**
+     * @return time of completion or null if not complete.
+     */
     public LocalDateTime getCompletionTimeUtc()
     {
-        return completionTimeUtc.get();
+        return completionTimeUtc;
     }
 
     public boolean isComplete()
     {
-        return completionTimeUtc.isPresent();
+        return completionTimeUtc != null;
     }
 
     @Override
@@ -75,7 +77,14 @@ public class RunInfo
 
         RunInfo runInfo = (RunInfo)o;
 
-        if ( !completionTimeUtc.equals(runInfo.completionTimeUtc) )
+        if ( completionTimeUtc == null )
+        {
+            if ( runInfo.completionTimeUtc != null )
+            {
+                return false;
+            }
+        }
+        else if ( !completionTimeUtc.equals(runInfo.completionTimeUtc) )
         {
             return false;
         }
@@ -97,7 +106,7 @@ public class RunInfo
     {
         int result = runId.hashCode();
         result = 31 * result + startTimeUtc.hashCode();
-        result = 31 * result + completionTimeUtc.hashCode();
+        result = 31 * result + (completionTimeUtc == null ? 0 : completionTimeUtc.hashCode());
         return result;
     }
 

--- a/src/main/java/com/nirmata/workflow/admin/StandardAutoCleaner.java
+++ b/src/main/java/com/nirmata/workflow/admin/StandardAutoCleaner.java
@@ -15,9 +15,10 @@
  */
 package com.nirmata.workflow.admin;
 
-import java.time.Clock;
-import java.time.Duration;
-import java.time.LocalDateTime;
+import org.joda.time.Duration;
+import org.joda.time.LocalDateTime;
+
+import static org.joda.time.DateTimeZone.UTC;
 
 /**
  * Default auto cleaner. Cleans if the run is completed and was completed past the given minimum age
@@ -36,8 +37,8 @@ public class StandardAutoCleaner implements AutoCleaner
     {
         if ( runInfo.isComplete() )
         {
-            LocalDateTime nowUtc = LocalDateTime.now(Clock.systemUTC());
-            Duration durationSinceCompletion = Duration.between(runInfo.getCompletionTimeUtc(), nowUtc);
+            LocalDateTime nowUtc = LocalDateTime.now(UTC);
+            Duration durationSinceCompletion = new Duration(runInfo.getCompletionTimeUtc().toDateTime(UTC), nowUtc.toDateTime(UTC));
             if ( durationSinceCompletion.compareTo(minAge) >= 0 )
             {
                 return true;

--- a/src/main/java/com/nirmata/workflow/admin/TaskDetails.java
+++ b/src/main/java/com/nirmata/workflow/admin/TaskDetails.java
@@ -21,7 +21,6 @@ import com.nirmata.workflow.models.Task;
 import com.nirmata.workflow.models.TaskId;
 import com.nirmata.workflow.models.TaskType;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Contains the meta-data and type from a submitted {@link Task}
@@ -29,13 +28,13 @@ import java.util.Optional;
 public class TaskDetails
 {
     private final TaskId taskId;
-    private final Optional<TaskType> taskType;
+    private final TaskType taskType;
     private final Map<String, String> metaData;
 
     public TaskDetails(TaskId taskId, TaskType taskType, Map<String, String> metaData)
     {
         this.taskId = Preconditions.checkNotNull(taskId, "taskId cannot be null");
-        this.taskType = Optional.ofNullable(taskType);
+        this.taskType = taskType;
         metaData = Preconditions.checkNotNull(metaData, "metaData cannot be null");
 
         this.metaData = ImmutableMap.copyOf(metaData);
@@ -48,12 +47,15 @@ public class TaskDetails
 
     public boolean isExecutable()
     {
-        return taskType.isPresent();
+        return taskType != null;
     }
 
+    /**
+     * Task type or null, if not executable.
+     */
     public TaskType getTaskType()
     {
-        return taskType.get();
+        return taskType;
     }
 
     public Map<String, String> getMetaData()
@@ -94,7 +96,14 @@ public class TaskDetails
             return false;
         }
         //noinspection RedundantIfStatement
-        if ( !taskType.equals(that.taskType) )
+        if ( taskType == null )
+        {
+            if ( that.taskType != null )
+            {
+                return false;
+            }
+        }
+        else if ( !taskType.equals(that.taskType) )
         {
             return false;
         }
@@ -106,7 +115,7 @@ public class TaskDetails
     public int hashCode()
     {
         int result = taskId.hashCode();
-        result = 31 * result + taskType.hashCode();
+        result = 31 * result + (taskType == null ? 0 : taskType.hashCode());
         result = 31 * result + metaData.hashCode();
         return result;
     }

--- a/src/main/java/com/nirmata/workflow/admin/TaskInfo.java
+++ b/src/main/java/com/nirmata/workflow/admin/TaskInfo.java
@@ -18,8 +18,7 @@ package com.nirmata.workflow.admin;
 import com.google.common.base.Preconditions;
 import com.nirmata.workflow.models.TaskExecutionResult;
 import com.nirmata.workflow.models.TaskId;
-import java.time.LocalDateTime;
-import java.util.Optional;
+import org.joda.time.LocalDateTime;
 
 /**
  * Task information
@@ -27,9 +26,9 @@ import java.util.Optional;
 public class TaskInfo
 {
     private final TaskId taskId;
-    private final Optional<String> instanceName;
-    private final Optional<LocalDateTime> startDateUtc;
-    private final Optional<TaskExecutionResult> result;
+    private final String instanceName;
+    private final LocalDateTime startDateUtc;
+    private final TaskExecutionResult result;
 
     public TaskInfo(TaskId taskId)
     {
@@ -44,9 +43,9 @@ public class TaskInfo
     public TaskInfo(TaskId taskId, String instanceName, LocalDateTime startDateUtc, TaskExecutionResult result)
     {
         this.taskId = Preconditions.checkNotNull(taskId, "taskId cannot be null");
-        this.instanceName = Optional.ofNullable(instanceName);
-        this.startDateUtc = Optional.ofNullable(startDateUtc);
-        this.result = Optional.ofNullable(result);
+        this.instanceName = instanceName;
+        this.startDateUtc = startDateUtc;
+        this.result = result;
     }
 
     public TaskId getTaskId()
@@ -54,29 +53,38 @@ public class TaskInfo
         return taskId;
     }
 
+    /**
+     * @return instance name or null if not started.
+     */
     public String getInstanceName()
     {
-        return instanceName.get();
+        return instanceName;
     }
 
+    /**
+     * @return start data name or null if not started.
+     */
     public LocalDateTime getStartDateUtc()
     {
-        return startDateUtc.get();
+        return startDateUtc;
     }
 
+    /**
+     * @return result or null if not complete
+     */
     public TaskExecutionResult getResult()
     {
-        return result.get();
+        return result;
     }
 
     public boolean hasStarted()
     {
-        return startDateUtc.isPresent() && instanceName.isPresent();
+        return startDateUtc != null && instanceName != null;
     }
 
     public boolean isComplete()
     {
-        return result.isPresent();
+        return result != null;
     }
 
     @Override
@@ -93,15 +101,36 @@ public class TaskInfo
 
         TaskInfo taskInfo = (TaskInfo)o;
 
-        if ( !instanceName.equals(taskInfo.instanceName) )
+        if ( instanceName == null )
+        {
+            if ( taskInfo.instanceName != null )
+            {
+                return false;
+            }
+        }
+        else if ( !instanceName.equals(taskInfo.instanceName) )
         {
             return false;
         }
-        if ( !result.equals(taskInfo.result) )
+        if ( result == null )
+        {
+            if ( taskInfo.result != null )
+            {
+                return false;
+            }
+        }
+        else if ( !result.equals(taskInfo.result) )
         {
             return false;
         }
-        if ( !startDateUtc.equals(taskInfo.startDateUtc) )
+        if ( startDateUtc == null )
+        {
+            if ( taskInfo.startDateUtc != null )
+            {
+                return false;
+            }
+        }
+        else if ( !startDateUtc.equals(taskInfo.startDateUtc) )
         {
             return false;
         }
@@ -118,9 +147,9 @@ public class TaskInfo
     public int hashCode()
     {
         int result1 = taskId.hashCode();
-        result1 = 31 * result1 + instanceName.hashCode();
-        result1 = 31 * result1 + startDateUtc.hashCode();
-        result1 = 31 * result1 + result.hashCode();
+        result1 = 31 * result1 + (instanceName == null ? 0 : instanceName.hashCode());
+        result1 = 31 * result1 + (startDateUtc == null ? 0 : startDateUtc.hashCode());
+        result1 = 31 * result1 + (result == null ? 0 : result.hashCode());
         return result1;
     }
 

--- a/src/main/java/com/nirmata/workflow/details/internalmodels/RunnableTask.java
+++ b/src/main/java/com/nirmata/workflow/details/internalmodels/RunnableTask.java
@@ -21,19 +21,18 @@ import com.google.common.collect.ImmutableMap;
 import com.nirmata.workflow.models.ExecutableTask;
 import com.nirmata.workflow.models.RunId;
 import com.nirmata.workflow.models.TaskId;
+import org.joda.time.LocalDateTime;
 import java.io.Serializable;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public class RunnableTask implements Serializable
 {
     private final Map<TaskId, ExecutableTask> tasks;
     private final List<RunnableTaskDag> taskDags;
     private final LocalDateTime startTimeUtc;
-    private final Optional<LocalDateTime> completionTimeUtc;
-    private final Optional<RunId> parentRunId;
+    private final LocalDateTime completionTimeUtc;
+    private final RunId parentRunId;
 
     public RunnableTask(Map<TaskId, ExecutableTask> tasks, List<RunnableTaskDag> taskDags, LocalDateTime startTimeUtc)
     {
@@ -48,8 +47,8 @@ public class RunnableTask implements Serializable
     public RunnableTask(Map<TaskId, ExecutableTask> tasks, List<RunnableTaskDag> taskDags, LocalDateTime startTimeUtc, LocalDateTime completionTimeUtc, RunId parentRunId)
     {
         this.startTimeUtc = Preconditions.checkNotNull(startTimeUtc, "startTimeUtc cannot be null");
-        this.completionTimeUtc = Optional.ofNullable(completionTimeUtc);
-        this.parentRunId = Optional.ofNullable(parentRunId);
+        this.completionTimeUtc = completionTimeUtc;
+        this.parentRunId = parentRunId;
         tasks = Preconditions.checkNotNull(tasks, "tasks cannot be null");
         taskDags = Preconditions.checkNotNull(taskDags, "taskDags cannot be null");
 
@@ -67,7 +66,10 @@ public class RunnableTask implements Serializable
         return taskDags;
     }
 
-    public Optional<LocalDateTime> getCompletionTimeUtc()
+    /**
+     * @return time of completion or null if not yet completed.
+     */
+    public LocalDateTime getCompletionTimeUtc()
     {
         return completionTimeUtc;
     }
@@ -77,7 +79,10 @@ public class RunnableTask implements Serializable
         return startTimeUtc;
     }
 
-    public Optional<RunId> getParentRunId()
+    /**
+     * @return id of parent or null, if this isn't a child task.
+     */
+    public RunId getParentRunId()
     {
         return parentRunId;
     }
@@ -96,11 +101,25 @@ public class RunnableTask implements Serializable
 
         RunnableTask that = (RunnableTask)o;
 
-        if ( !completionTimeUtc.equals(that.completionTimeUtc) )
+        if ( completionTimeUtc == null )
+        {
+            if ( that.completionTimeUtc != null )
+            {
+                return false;
+            }
+        }
+        else if ( !completionTimeUtc.equals(that.completionTimeUtc) )
         {
             return false;
         }
-        if ( !parentRunId.equals(that.parentRunId) )
+        if ( parentRunId == null )
+        {
+            if ( that.parentRunId != null )
+            {
+                return false;
+            }
+        }
+        else if ( !parentRunId.equals(that.parentRunId) )
         {
             return false;
         }
@@ -127,8 +146,8 @@ public class RunnableTask implements Serializable
         int result = tasks.hashCode();
         result = 31 * result + taskDags.hashCode();
         result = 31 * result + startTimeUtc.hashCode();
-        result = 31 * result + completionTimeUtc.hashCode();
-        result = 31 * result + parentRunId.hashCode();
+        result = 31 * result + (completionTimeUtc == null ? 0 : completionTimeUtc.hashCode());
+        result = 31 * result + (parentRunId == null ? 0 : parentRunId.hashCode());
         return result;
     }
 

--- a/src/main/java/com/nirmata/workflow/details/internalmodels/StartedTask.java
+++ b/src/main/java/com/nirmata/workflow/details/internalmodels/StartedTask.java
@@ -16,8 +16,8 @@
 package com.nirmata.workflow.details.internalmodels;
 
 import com.google.common.base.Preconditions;
+import org.joda.time.LocalDateTime;
 import java.io.Serializable;
-import java.time.LocalDateTime;
 
 public class StartedTask implements Serializable
 {

--- a/src/main/java/com/nirmata/workflow/events/WorkflowEvent.java
+++ b/src/main/java/com/nirmata/workflow/events/WorkflowEvent.java
@@ -17,7 +17,6 @@ package com.nirmata.workflow.events;
 
 import com.nirmata.workflow.models.RunId;
 import com.nirmata.workflow.models.TaskId;
-import java.util.Optional;
 
 /**
  * Models a workflow event
@@ -52,7 +51,7 @@ public class WorkflowEvent
 
     private final EventType type;
     private final RunId runId;
-    private final Optional<TaskId> taskId;
+    private final TaskId taskId;
 
     public WorkflowEvent(EventType type, RunId runId)
     {
@@ -63,7 +62,7 @@ public class WorkflowEvent
     {
         this.type = type;
         this.runId = runId;
-        this.taskId = Optional.ofNullable(taskId);
+        this.taskId = taskId;
     }
 
     public EventType getType()
@@ -76,7 +75,10 @@ public class WorkflowEvent
         return runId;
     }
 
-    public Optional<TaskId> getTaskId()
+    /**
+     * @return task id or null if not started.
+     */
+    public TaskId getTaskId()
     {
         return taskId;
     }
@@ -99,7 +101,14 @@ public class WorkflowEvent
         {
             return false;
         }
-        if ( !taskId.equals(that.taskId) )
+        if ( taskId == null )
+        {
+            if ( that.taskId != null )
+            {
+                return false;
+            }
+        }
+        else if ( !taskId.equals(that.taskId) )
         {
             return false;
         }
@@ -117,7 +126,7 @@ public class WorkflowEvent
     {
         int result = type.hashCode();
         result = 31 * result + runId.hashCode();
-        result = 31 * result + taskId.hashCode();
+        result = 31 * result + (taskId == null ? 0 : taskId.hashCode());
         return result;
     }
 

--- a/src/main/java/com/nirmata/workflow/events/WorkflowListener.java
+++ b/src/main/java/com/nirmata/workflow/events/WorkflowListener.java
@@ -15,7 +15,6 @@
  */
 package com.nirmata.workflow.events;
 
-@FunctionalInterface
 public interface WorkflowListener
 {
     /**

--- a/src/main/java/com/nirmata/workflow/executor/TaskExecution.java
+++ b/src/main/java/com/nirmata/workflow/executor/TaskExecution.java
@@ -22,7 +22,6 @@ import com.nirmata.workflow.models.TaskExecutionResult;
  * task. The Workflow manager will call {@link #execute()} when the task should perform
  * its operation.
  */
-@FunctionalInterface
 public interface TaskExecution
 {
     /**

--- a/src/main/java/com/nirmata/workflow/executor/TaskExecutor.java
+++ b/src/main/java/com/nirmata/workflow/executor/TaskExecutor.java
@@ -21,7 +21,6 @@ import com.nirmata.workflow.models.ExecutableTask;
 /**
  * Factory for creating task executions
  */
-@FunctionalInterface
 public interface TaskExecutor
 {
     /**

--- a/src/main/java/com/nirmata/workflow/queue/TaskRunner.java
+++ b/src/main/java/com/nirmata/workflow/queue/TaskRunner.java
@@ -17,7 +17,6 @@ package com.nirmata.workflow.queue;
 
 import com.nirmata.workflow.models.ExecutableTask;
 
-@FunctionalInterface
 public interface TaskRunner
 {
     public void executeTask(ExecutableTask executableTask);

--- a/src/main/java/com/nirmata/workflow/serialization/JsonSerializerMapper.java
+++ b/src/main/java/com/nirmata/workflow/serialization/JsonSerializerMapper.java
@@ -49,7 +49,7 @@ public class JsonSerializerMapper
         ImmutableMap.Builder<Class<?>, Methods> builder = ImmutableMap.builder();
         for ( Method method : JsonSerializer.class.getDeclaredMethods() )
         {
-            if ( method.getName().startsWith(NEW_PREFIX) && (method.getReturnType() == JsonNode.class) && (method.getParameterCount() == 1) )
+            if ( method.getName().startsWith(NEW_PREFIX) && (method.getReturnType() == JsonNode.class) && (method.getParameterTypes().length == 1) )
             {
                 String className = method.getName().substring(NEW_PREFIX.length());
                 Method getter = getGetter(className);

--- a/src/test/java/com/nirmata/workflow/TestAutoCleanerHolder.java
+++ b/src/test/java/com/nirmata/workflow/TestAutoCleanerHolder.java
@@ -25,14 +25,15 @@ import com.nirmata.workflow.details.AutoCleanerHolder;
 import com.nirmata.workflow.models.RunId;
 import com.nirmata.workflow.models.TaskId;
 import org.apache.curator.test.Timing;
+import org.joda.time.Duration;
+import org.joda.time.LocalDateTime;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import java.time.Clock;
-import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import static org.joda.time.DateTimeZone.UTC;
 
 public class TestAutoCleanerHolder
 {
@@ -40,7 +41,7 @@ public class TestAutoCleanerHolder
     public void testNull() throws InterruptedException
     {
         Timing timing = new Timing();
-        AutoCleanerHolder holder = new AutoCleanerHolder(null, Duration.ofDays(10));
+        AutoCleanerHolder holder = new AutoCleanerHolder(null, Duration.standardDays(10));
         Assert.assertFalse(holder.shouldRun());
         Assert.assertFalse(holder.shouldRun());
         timing.sleepABit();
@@ -53,7 +54,7 @@ public class TestAutoCleanerHolder
     @Test
     public void testPeriod() throws InterruptedException
     {
-        AutoCleanerHolder holder = new AutoCleanerHolder(new StandardAutoCleaner(Duration.ofSeconds(2)), Duration.ofSeconds(1));
+        AutoCleanerHolder holder = new AutoCleanerHolder(new StandardAutoCleaner(Duration.standardSeconds(2)), Duration.standardSeconds(1));
         Assert.assertFalse(holder.shouldRun());
         TimeUnit.SECONDS.sleep(2);
         Assert.assertTrue(holder.shouldRun());
@@ -62,9 +63,9 @@ public class TestAutoCleanerHolder
         RunId completedId = new RunId();
         RunId completedButRecentId = new RunId();
         List<RunInfo> runs = Lists.newArrayList(
-            new RunInfo(runningId, LocalDateTime.now(Clock.systemUTC())),
-            new RunInfo(completedButRecentId, LocalDateTime.now(Clock.systemUTC()), LocalDateTime.now(Clock.systemUTC())),
-            new RunInfo(completedId, LocalDateTime.now(Clock.systemUTC()), LocalDateTime.now(Clock.systemUTC()).minusSeconds(3))
+            new RunInfo(runningId, LocalDateTime.now(UTC)),
+            new RunInfo(completedButRecentId, LocalDateTime.now(UTC), LocalDateTime.now(UTC)),
+            new RunInfo(completedId, LocalDateTime.now(UTC), LocalDateTime.now(UTC).minusSeconds(3))
         );
 
         List<RunId> cleaned = Lists.newArrayList();

--- a/src/test/java/com/nirmata/workflow/TestNormal.java
+++ b/src/test/java/com/nirmata/workflow/TestNormal.java
@@ -16,10 +16,10 @@
 
 package com.nirmata.workflow;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
-import com.google.common.collect.Sets;
 import com.google.common.io.Resources;
 import com.nirmata.workflow.admin.RunInfo;
 import com.nirmata.workflow.admin.StandardAutoCleaner;
@@ -35,14 +35,13 @@ import com.nirmata.workflow.models.TaskType;
 import com.nirmata.workflow.serialization.JsonSerializerMapper;
 import org.apache.curator.test.Timing;
 import org.apache.curator.utils.CloseableUtils;
+import org.joda.time.Duration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import java.nio.charset.Charset;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -92,8 +91,8 @@ public class TestNormal extends BaseForTests
             List<Set<TaskId>> sets = taskExecutor.getChecker().getSets();
             List<Set<TaskId>> expectedSets = Arrays.<Set<TaskId>>asList
                 (
-                    Sets.newHashSet(new TaskId("task1")),
-                    Sets.newHashSet(new TaskId("task2"))
+                    ImmutableSet.of(new TaskId("task1")),
+                    ImmutableSet.of(new TaskId("task2"))
                 );
             Assert.assertEquals(sets, expectedSets);
         }
@@ -113,7 +112,7 @@ public class TestNormal extends BaseForTests
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
             .addingTaskExecutor(taskExecutor, 10, taskType)
             .withCurator(curator, "test", "1")
-            .withAutoCleaner(new StandardAutoCleaner(Duration.ofMillis(1)), Duration.ofMillis(1))
+            .withAutoCleaner(new StandardAutoCleaner(Duration.millis(1)), Duration.millis(1))
             .build();
         try
         {
@@ -201,9 +200,9 @@ public class TestNormal extends BaseForTests
             List<Set<TaskId>> sets = taskExecutor.getChecker().getSets();
             List<Set<TaskId>> expectedSets = Arrays.<Set<TaskId>>asList
                 (
-                    Sets.newHashSet(new TaskId("task1"), new TaskId("task2")),
-                    Sets.newHashSet(new TaskId("task3"), new TaskId("task4"), new TaskId("task5")),
-                    Sets.newHashSet(new TaskId("task6"))
+                    ImmutableSet.of(new TaskId("task1"), new TaskId("task2")),
+                    ImmutableSet.of(new TaskId("task3"), new TaskId("task4"), new TaskId("task5")),
+                    ImmutableSet.of(new TaskId("task6"))
                 );
             Assert.assertEquals(sets, expectedSets);
 
@@ -246,9 +245,9 @@ public class TestNormal extends BaseForTests
             List<Set<TaskId>> sets = taskExecutor.getChecker().getSets();
             List<Set<TaskId>> expectedSets = Arrays.<Set<TaskId>>asList
                 (
-                    Sets.newHashSet(new TaskId("task1"), new TaskId("task2")),
-                    Sets.newHashSet(new TaskId("task3"), new TaskId("task4"), new TaskId("task5")),
-                    Sets.newHashSet(new TaskId("task6"))
+                    ImmutableSet.of(new TaskId("task1"), new TaskId("task2")),
+                    ImmutableSet.of(new TaskId("task3"), new TaskId("task4"), new TaskId("task5")),
+                    ImmutableSet.of(new TaskId("task6"))
                 );
             Assert.assertEquals(sets, expectedSets);
 
@@ -268,8 +267,8 @@ public class TestNormal extends BaseForTests
             .withCurator(curator, "test", "1")
             .build();
 
-        Optional<TaskExecutionResult> taskData = workflowManager.getTaskExecutionResult(new RunId(), new TaskId());
-        Assert.assertFalse(taskData.isPresent());
+        TaskExecutionResult taskData = workflowManager.getTaskExecutionResult(new RunId(), new TaskId());
+        Assert.assertNull(taskData);
     }
 
     @Test
@@ -299,12 +298,12 @@ public class TestNormal extends BaseForTests
             Assert.assertTrue(timing.awaitLatch(latch));
             timing.sleepABit();
 
-            Optional<TaskExecutionResult> taskData = workflowManager.getTaskExecutionResult(runId, taskId);
-            Assert.assertTrue(taskData.isPresent());
+            TaskExecutionResult taskData = workflowManager.getTaskExecutionResult(runId, taskId);
+            Assert.assertNotNull(taskData);
             Map<String, String> expected = Maps.newHashMap();
             expected.put("one", "1");
             expected.put("two", "2");
-            Assert.assertEquals(taskData.get().getResultData(), expected);
+            Assert.assertEquals(taskData.getResultData(), expected);
         }
         finally
         {
@@ -396,9 +395,9 @@ public class TestNormal extends BaseForTests
             List<Set<TaskId>> sets = taskExecutor.getChecker().getSets();
             List<Set<TaskId>> expectedSets = Arrays.<Set<TaskId>>asList
                 (
-                    Sets.newHashSet(new TaskId("task1"), new TaskId("task2")),
-                    Sets.newHashSet(new TaskId("task3"), new TaskId("task4"), new TaskId("task5")),
-                    Sets.newHashSet(new TaskId("task6"))
+                    ImmutableSet.of(new TaskId("task1"), new TaskId("task2")),
+                    ImmutableSet.of(new TaskId("task3"), new TaskId("task4"), new TaskId("task5")),
+                    ImmutableSet.of(new TaskId("task6"))
                 );
             Assert.assertEquals(sets, expectedSets);
 
@@ -451,13 +450,13 @@ public class TestNormal extends BaseForTests
             workflowManager.submitTask(task);
 
             Timing timing = new Timing();
-            Set<TaskId> set1 = Sets.newHashSet(queue1.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), queue1.poll(timing.milliseconds(), TimeUnit.MILLISECONDS));
-            Set<TaskId> set2 = Sets.newHashSet(queue2.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), queue2.poll(timing.milliseconds(), TimeUnit.MILLISECONDS));
-            Set<TaskId> set3 = Sets.newHashSet(queue3.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), queue3.poll(timing.milliseconds(), TimeUnit.MILLISECONDS));
+            Set<TaskId> set1 = ImmutableSet.of(queue1.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), queue1.poll(timing.milliseconds(), TimeUnit.MILLISECONDS));
+            Set<TaskId> set2 = ImmutableSet.of(queue2.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), queue2.poll(timing.milliseconds(), TimeUnit.MILLISECONDS));
+            Set<TaskId> set3 = ImmutableSet.of(queue3.poll(timing.milliseconds(), TimeUnit.MILLISECONDS), queue3.poll(timing.milliseconds(), TimeUnit.MILLISECONDS));
 
-            Assert.assertEquals(set1, Sets.newHashSet(new TaskId("task1"), new TaskId("task2")));
-            Assert.assertEquals(set2, Sets.newHashSet(new TaskId("task3"), new TaskId("task4")));
-            Assert.assertEquals(set3, Sets.newHashSet(new TaskId("task5"), new TaskId("task6")));
+            Assert.assertEquals(set1, ImmutableSet.of(new TaskId("task1"), new TaskId("task2")));
+            Assert.assertEquals(set2, ImmutableSet.of(new TaskId("task3"), new TaskId("task4")));
+            Assert.assertEquals(set3, ImmutableSet.of(new TaskId("task5"), new TaskId("task6")));
 
             timing.sleepABit();
 

--- a/src/test/java/com/nirmata/workflow/serialization/TestSerializer.java
+++ b/src/test/java/com/nirmata/workflow/serialization/TestSerializer.java
@@ -29,12 +29,11 @@ import com.nirmata.workflow.models.Task;
 import com.nirmata.workflow.models.TaskExecutionResult;
 import com.nirmata.workflow.models.TaskId;
 import com.nirmata.workflow.models.TaskType;
+import org.joda.time.LocalDateTime;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.time.Clock;
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +43,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.nirmata.workflow.serialization.JsonSerializer.*;
+import static org.joda.time.DateTimeZone.UTC;
 
 public class TestSerializer
 {
@@ -84,9 +84,9 @@ public class TestSerializer
             .limit(random.nextInt(3) + 1)
             .collect(Collectors.toList())
             ;
-        LocalDateTime completionTime = random.nextBoolean() ? LocalDateTime.now() : null;
+        LocalDateTime completionTime = random.nextBoolean() ? LocalDateTime.now(UTC) : null;
         RunId parentRunId = random.nextBoolean() ? new RunId() : null;
-        RunnableTask runnableTask = new RunnableTask(tasks, taskDags, LocalDateTime.now(), completionTime, parentRunId);
+        RunnableTask runnableTask = new RunnableTask(tasks, taskDags, LocalDateTime.now(UTC), completionTime, parentRunId);
         JsonNode node = newRunnableTask(runnableTask);
         String str = nodeToString(node);
         System.out.println(str);
@@ -110,7 +110,7 @@ public class TestSerializer
     @Test
     public void testStartedTask()
     {
-        StartedTask startedTask = new StartedTask(Integer.toString(random.nextInt()), LocalDateTime.now(Clock.systemUTC()));
+        StartedTask startedTask = new StartedTask(Integer.toString(random.nextInt()), LocalDateTime.now(UTC));
         JsonNode node = newStartedTask(startedTask);
         String str = nodeToString(node);
         System.out.println(str);
@@ -179,7 +179,7 @@ public class TestSerializer
     {
         JDKSerializer serializer = new JDKSerializer();
 
-        StartedTask startedTask = new StartedTask(Integer.toString(random.nextInt()), LocalDateTime.now(Clock.systemUTC()));
+        StartedTask startedTask = new StartedTask(Integer.toString(random.nextInt()), LocalDateTime.now(UTC));
         byte[] bytes = serializer.serialize(startedTask);
         StartedTask unStartedTask = serializer.deserialize(bytes, StartedTask.class);
         Assert.assertEquals(startedTask, unStartedTask);


### PR DESCRIPTION
Java 8 is supported in many runtimes, including the incubating scala
2.12. Twitter is still on scala 2.10.5, and our pants CI build runs on
JDK 7. While we are likely to move to a Java 8 friendly toolchain,
status quo is incompatible with Java 8 libraries. My hope is that by
backporting this, users such as Twitter can more easily adopt workflow
decoupled from our transition towards Java 8.