### PR TITLE
[Issue 33] Make Workflow resilient to parent node deletions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <curator-version>4.0.1-SNAPSHOT</curator-version>
+        <curator-version>4.0.1</curator-version>
         <jackson-version>2.8.6</jackson-version>
         <testng-version>6.10</testng-version>
         <slf4j-version>1.7.22</slf4j-version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <curator-version>3.2.1</curator-version>
+        <curator-version>4.0.1-SNAPSHOT</curator-version>
         <jackson-version>2.8.6</jackson-version>
         <testng-version>6.10</testng-version>
         <slf4j-version>1.7.22</slf4j-version>

--- a/src/main/java/com/nirmata/workflow/details/Scheduler.java
+++ b/src/main/java/com/nirmata/workflow/details/Scheduler.java
@@ -44,7 +44,6 @@ import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -210,9 +209,6 @@ class Scheduler
         }
     }
 
-    @VisibleForTesting
-    static volatile Semaphore debugQueuedTasks = null;
-
     private void updateTasks(RunId runId)
     {
         log.info("Updating run: " + runId);
@@ -296,11 +292,6 @@ class Scheduler
             Queue queue = queues.get(task.getTaskType());
             queue.put(task);
             log.info("Queued task: " + task);
-
-            if ( debugQueuedTasks != null )
-            {
-                debugQueuedTasks.release();
-            }
         }
         catch ( KeeperException.NodeExistsException ignore )
         {

--- a/src/main/java/com/nirmata/workflow/details/WorkflowManagerImpl.java
+++ b/src/main/java/com/nirmata/workflow/details/WorkflowManagerImpl.java
@@ -50,6 +50,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -285,7 +286,7 @@ public class WorkflowManagerImpl implements WorkflowManager, WorkflowAdmin
     }
 
     @Override
-    public void close() throws IOException
+    public void close()
     {
         if ( state.compareAndSet(State.STARTED, State.CLOSED) )
         {
@@ -396,10 +397,15 @@ public class WorkflowManagerImpl implements WorkflowManager, WorkflowAdmin
                 .map(RunId::new)
                 .collect(Collectors.toList());
         }
+        catch ( KeeperException.NoNodeException ignore )
+        {
+            // ignore if parent node is missing
+        }
         catch ( Exception e )
         {
             throw new RuntimeException(e);
         }
+        return Collections.emptyList();
     }
 
     @Override

--- a/src/main/java/com/nirmata/workflow/details/ZooKeeperConstants.java
+++ b/src/main/java/com/nirmata/workflow/details/ZooKeeperConstants.java
@@ -78,6 +78,11 @@ public class ZooKeeperConstants
         return RUN_PATH;
     }
 
+    public static String getQueuePathBase()
+    {
+        return QUEUE_PATH_BASE;
+    }
+
     public static String getRunPath(RunId runId)
     {
         return ZKPaths.makePath(RUN_PATH, runId.getId());

--- a/src/test/java/com/nirmata/workflow/TestParentNodeDeletion.java
+++ b/src/test/java/com/nirmata/workflow/TestParentNodeDeletion.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2014 Nirmata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.nirmata.workflow;
+
+import com.nirmata.workflow.admin.AutoCleaner;
+import com.nirmata.workflow.admin.StandardAutoCleaner;
+import com.nirmata.workflow.details.ZooKeeperConstants;
+import com.nirmata.workflow.executor.TaskExecutionStatus;
+import com.nirmata.workflow.executor.TaskExecutor;
+import com.nirmata.workflow.models.RunId;
+import com.nirmata.workflow.models.Task;
+import com.nirmata.workflow.models.TaskExecutionResult;
+import com.nirmata.workflow.models.TaskId;
+import com.nirmata.workflow.models.TaskType;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+public class TestParentNodeDeletion extends BaseForTests
+{
+    private static final String TASK_NAME = "TestTask";
+    private static final String VERSION = "v1";
+    private static final TaskType TASK_TYPE = new TaskType(TASK_NAME, VERSION, true);
+    private static final int CONCURRENT_TASKS = 5;
+
+    private static final Logger log = LoggerFactory.getLogger(TestParentNodeDeletion.class);
+
+    @Test
+    public void testParentNodeDeletion() throws Exception
+    {
+        final String namespace = "test";
+        final String workflowPath = "/" + namespace + "-" + VERSION;
+
+        try ( CuratorFramework curator = newCurator() )
+        {
+            WorkflowManager workflowManager = buildWorkflow(curator, namespace);
+            RunId runId = submitTask(workflowManager);
+            assertTask(workflowManager, runId);
+
+            String runPath = ZKPaths.makePath(workflowPath, ZooKeeperConstants.getRunParentPath());
+            String startedPath = ZKPaths.makePath(workflowPath, ZooKeeperConstants.getStartedTasksParentPath());
+            String completedPath = ZKPaths.makePath(workflowPath, ZooKeeperConstants.getCompletedTaskParentPath());
+            String queuePath = ZKPaths.makePath(workflowPath, ZooKeeperConstants.getQueuePathBase());
+
+            deletePath(curator, runPath);
+            deletePath(curator, startedPath);
+            deletePath(curator, completedPath);
+
+            timing.sleepABit();
+
+            runId = submitTask(workflowManager);
+            assertTask(workflowManager, runId);
+        }
+    }
+
+    private void assertTask(WorkflowManager workflowManager, RunId runId) throws Exception
+    {
+        Assert.assertTrue(workflowManager.getAdmin().getRunIds().contains(runId));
+        long start = System.nanoTime();
+        for(;;)
+        {
+            long elapsed = System.nanoTime() - start;
+            if ( TimeUnit.NANOSECONDS.toMillis(elapsed) > timing.forWaiting().milliseconds() )
+            {
+                Assert.fail("Task did not execute within timeout");
+            }
+            Assert.assertTrue(workflowManager.getAdmin().getRunIds().contains(runId));
+            if ( workflowManager.getAdmin().getRunInfo(runId).isComplete() )
+            {
+                break;
+            }
+            timing.sleepABit();
+        }
+    }
+
+    private void deletePath(CuratorFramework curator, String path) throws Exception
+    {
+        try
+        {
+            curator.delete().deletingChildrenIfNeeded().forPath(path);
+        }
+        catch ( KeeperException ignore )
+        {
+            // ignore
+        }
+    }
+
+    private CuratorFramework newCurator()
+    {
+        final CuratorFramework curator = CuratorFrameworkFactory.newClient(server.getConnectString(), timing.session(), timing.connection(), new ExponentialBackoffRetry(1000, 10));
+        curator.start();
+        return curator;
+    }
+
+    private WorkflowManager buildWorkflow(CuratorFramework curator, String namespace)
+    {
+        Duration runPeriod = Duration.ofSeconds(5);
+        AutoCleaner cleaner = new StandardAutoCleaner(Duration.ofSeconds(5));
+
+        final WorkflowManagerBuilder workflowManagerBuilder = WorkflowManagerBuilder.builder().withCurator(curator, namespace, VERSION).withAutoCleaner(cleaner, runPeriod);
+
+        final TaskExecutor taskExecutor = (workflowManager, executableTask) -> () -> {
+            final String runId = executableTask.getRunId().getId();
+            final String taskId = executableTask.getTaskId().getId();
+            log.debug("execute task {} - {}", runId, taskId);
+
+            return new TaskExecutionResult(TaskExecutionStatus.SUCCESS, "");
+        };
+
+        workflowManagerBuilder.addingTaskExecutor(taskExecutor, CONCURRENT_TASKS, TASK_TYPE);
+
+        final WorkflowManager workflowManager = workflowManagerBuilder.build();
+        workflowManager.start();
+
+        return workflowManager;
+    }
+
+    private RunId submitTask(WorkflowManager workflowManager)
+    {
+        TaskId taskId = new TaskId();
+        Task task = new Task(taskId, TASK_TYPE);
+        RunId runId = workflowManager.submitTask(task);
+        log.debug("submit task done - runId {}", runId.getId());
+        return runId;
+    }
+}

--- a/src/test/java/com/nirmata/workflow/details/TestDelayPriorityTasks.java
+++ b/src/test/java/com/nirmata/workflow/details/TestDelayPriorityTasks.java
@@ -26,6 +26,7 @@ import com.nirmata.workflow.models.TaskExecutionResult;
 import com.nirmata.workflow.models.TaskId;
 import com.nirmata.workflow.models.TaskMode;
 import com.nirmata.workflow.models.TaskType;
+import com.nirmata.workflow.queue.zookeeper.SimpleQueue;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import java.util.concurrent.BlockingQueue;
@@ -94,7 +95,7 @@ public class TestDelayPriorityTasks extends BaseForTests
             .withCurator(curator, "test", "1")
             .build() )
         {
-            Scheduler.debugQueuedTasks = new Semaphore(0);
+            SimpleQueue.debugQueuedTasks = new Semaphore(0);
             ((WorkflowManagerImpl)workflowManager).debugDontStartConsumers = true; // make sure all tasks are added to ZK before they start getting consumed
             workflowManager.start();
 
@@ -109,7 +110,7 @@ public class TestDelayPriorityTasks extends BaseForTests
             workflowManager.submitTask(task4);
             workflowManager.submitTask(task5);
 
-            Assert.assertTrue(Scheduler.debugQueuedTasks.tryAcquire(5, 5, TimeUnit.SECONDS));
+            Assert.assertTrue(SimpleQueue.debugQueuedTasks.tryAcquire(5, 5, TimeUnit.SECONDS));
             ((WorkflowManagerImpl)workflowManager).startQueueConsumers();
 
             Assert.assertEquals(queue.poll(1, TimeUnit.SECONDS), "1");
@@ -120,7 +121,7 @@ public class TestDelayPriorityTasks extends BaseForTests
         }
         finally
         {
-            Scheduler.debugQueuedTasks = null;
+            SimpleQueue.debugQueuedTasks = null;
         }
     }
 }


### PR DESCRIPTION
Closes #33 

Note: this is dependent on an Apache Curator release and must be updated (for the dependency) when that happens

1) Use latest Apache Curator which includes fix for https://issues.apache.org/jira/browse/CURATOR-388
2) Make various parts of the code resilient to parent nodes getting deleted due to container deletion, etc.

## Note

This is not currently testable as it uses a snapshot version of Curator

If you really want to test this, build Curator locally first:

- `git clone https://github.com/apache/curator.git`
- `cd curator`
- `git checkout CURATOR-388`
- `mvn -DskipTests -Darguments="-DskipTests" clean install`

This will install Curator `4.0.1-SNAPSHOT` and then this PR will work.