### PR TITLE
Closing SimpleQueue and WorkflowManager gracefully

### DIFF
--- a/src/main/java/com/nirmata/workflow/WorkflowManager.java
+++ b/src/main/java/com/nirmata/workflow/WorkflowManager.java
@@ -146,7 +146,8 @@ public interface WorkflowManager extends Closeable
      *  Close the workflow manager gracefully by allowing the in-progress tasks to continue till the timeout specified.
      *  This method is different from close method(Closeable) as close method will stop the in-progress tasks as well.
      *
-     * @param timeOut is the maximum time(in seconds) allocated for the in-progress tasks to complete the execution.
+     * @param timeOut is the maximum time allocated for the in-progress tasks to complete the execution.
+     * @param unit Timeunit for the timeOut quantity specified
      */
-    void closeGracefully(long timeOut);
+    void closeGracefully(long timeOut, TimeUnit unit);
 }

--- a/src/main/java/com/nirmata/workflow/WorkflowManager.java
+++ b/src/main/java/com/nirmata/workflow/WorkflowManager.java
@@ -25,6 +25,7 @@ import com.nirmata.workflow.models.TaskId;
 import org.apache.curator.framework.CuratorFramework;
 import java.io.Closeable;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Main API - create via {@link WorkflowManagerBuilder}
@@ -140,4 +141,12 @@ public interface WorkflowManager extends Closeable
      * @return new WorkflowListenerManager
      */
     WorkflowListenerManager newWorkflowListenerManager();
+
+    /**
+     *  Close the workflow manager gracefully by allowing the in-progress tasks to continue till the timeout specified.
+     *  This method is different from close method(Closeable) as close method will stop the in-progress tasks as well.
+     *
+     * @param timeOut is the maximum time(in seconds) allocated for the in-progress tasks to complete the execution.
+     */
+    void closeGracefully(long timeOut);
 }

--- a/src/main/java/com/nirmata/workflow/details/WorkflowManagerImpl.java
+++ b/src/main/java/com/nirmata/workflow/details/WorkflowManagerImpl.java
@@ -58,6 +58,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -129,11 +130,11 @@ public class WorkflowManagerImpl implements WorkflowManager, WorkflowAdmin
     }
 
     @Override
-    public void closeGracefully(long timeOut) {
+    public void closeGracefully(long timeOut, TimeUnit unit) {
         if ( state.compareAndSet(State.STARTED, State.CLOSED) )
         {
             CloseableUtils.closeQuietly(schedulerSelector);
-            consumers.forEach(consumer -> consumer.closeGraceFully(timeOut));
+            consumers.forEach(consumer -> consumer.closeGraceFully(timeOut, unit));
         }
     }
 

--- a/src/main/java/com/nirmata/workflow/details/WorkflowManagerImpl.java
+++ b/src/main/java/com/nirmata/workflow/details/WorkflowManagerImpl.java
@@ -129,6 +129,15 @@ public class WorkflowManagerImpl implements WorkflowManager, WorkflowAdmin
     }
 
     @Override
+    public void closeGracefully(long timeOut) {
+        if ( state.compareAndSet(State.STARTED, State.CLOSED) )
+        {
+            CloseableUtils.closeQuietly(schedulerSelector);
+            consumers.forEach(consumer -> consumer.closeGraceFully(timeOut));
+        }
+    }
+
+    @Override
     public Map<TaskId, TaskDetails> getTaskDetails(RunId runId)
     {
         try

--- a/src/main/java/com/nirmata/workflow/queue/QueueConsumer.java
+++ b/src/main/java/com/nirmata/workflow/queue/QueueConsumer.java
@@ -18,6 +18,7 @@ package com.nirmata.workflow.queue;
 import com.google.common.annotations.VisibleForTesting;
 import com.nirmata.workflow.admin.WorkflowManagerState;
 import java.io.Closeable;
+import java.util.concurrent.TimeUnit;
 
 public interface QueueConsumer extends Closeable
 {
@@ -33,7 +34,8 @@ public interface QueueConsumer extends Closeable
 
     /**
      * Allowing the executorService(SimpleQueue) to finish the previously submitted tasks before shutting down
-     * @param timeOut (in seconds)
+     * @param timeOut
+     * @param unit Timeunit for the timeOut quantity specified
      */
-    void closeGraceFully(long timeOut);
+    void closeGraceFully(long timeOut, TimeUnit unit);
 }

--- a/src/main/java/com/nirmata/workflow/queue/QueueConsumer.java
+++ b/src/main/java/com/nirmata/workflow/queue/QueueConsumer.java
@@ -30,4 +30,10 @@ public interface QueueConsumer extends Closeable
 
     @VisibleForTesting
     void debugValidateClosed();
+
+    /**
+     * Allowing the executorService(SimpleQueue) to finish the previously submitted tasks before shutting down
+     * @param timeOut (in seconds)
+     */
+    void closeGraceFully(long timeOut);
 }

--- a/src/main/java/com/nirmata/workflow/queue/zookeeper/SimpleQueue.java
+++ b/src/main/java/com/nirmata/workflow/queue/zookeeper/SimpleQueue.java
@@ -201,13 +201,13 @@ public class SimpleQueue implements Closeable, QueueConsumer
     }
 
     @Override
-    public void closeGraceFully(long timeOut) {
+    public void closeGraceFully(long timeOut, TimeUnit unit) {
         if ( started.compareAndSet(true, false) )
         {
             executorService.shutdown();
             try {
                 log.info("Blocks until all tasks have completed execution or the timeout occurs");
-                executorService.awaitTermination(timeOut, TimeUnit.SECONDS);
+                executorService.awaitTermination(timeOut, unit);
                 log.info("Simple Queue executor service shutdown completed");
             } catch (InterruptedException e) {
                 log.error("Error while processing of in-progress tasks, possibly due to timeout while waiting", e);

--- a/src/main/java/com/nirmata/workflow/queue/zookeeper/SimpleQueue.java
+++ b/src/main/java/com/nirmata/workflow/queue/zookeeper/SimpleQueue.java
@@ -200,6 +200,20 @@ public class SimpleQueue implements Closeable, QueueConsumer
         Preconditions.checkState(executorService.isTerminated());
     }
 
+    @Override
+    public void closeGraceFully(long timeOut) {
+        if ( started.compareAndSet(true, false) )
+        {
+            executorService.shutdown();
+            try {
+                executorService.awaitTermination(timeOut, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                log.error("Error while processing of in-progress tasks, possibly due to timeout while waiting", e);
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
     public void start()
     {
         if ( started.compareAndSet(false, true) )

--- a/src/main/java/com/nirmata/workflow/queue/zookeeper/SimpleQueue.java
+++ b/src/main/java/com/nirmata/workflow/queue/zookeeper/SimpleQueue.java
@@ -206,7 +206,9 @@ public class SimpleQueue implements Closeable, QueueConsumer
         {
             executorService.shutdown();
             try {
+                log.info("Blocks until all tasks have completed execution or the timeout occurs");
                 executorService.awaitTermination(timeOut, TimeUnit.SECONDS);
+                log.info("Simple Queue executor service shutdown completed");
             } catch (InterruptedException e) {
                 log.error("Error while processing of in-progress tasks, possibly due to timeout while waiting", e);
                 Thread.currentThread().interrupt();

--- a/src/main/java/com/nirmata/workflow/queue/zookeeper/SimpleQueue.java
+++ b/src/main/java/com/nirmata/workflow/queue/zookeeper/SimpleQueue.java
@@ -18,6 +18,7 @@ package com.nirmata.workflow.queue.zookeeper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.nirmata.workflow.admin.WorkflowManagerState;
 import com.nirmata.workflow.models.ExecutableTask;
 import com.nirmata.workflow.models.TaskMode;
@@ -204,12 +205,11 @@ public class SimpleQueue implements Closeable, QueueConsumer
     public void closeGraceFully(long timeOut, TimeUnit unit) {
         if ( started.compareAndSet(true, false) )
         {
-            executorService.shutdown();
+            log.info("Blocks until all tasks have completed execution or the timeout occurs");
             try {
-                log.info("Blocks until all tasks have completed execution or the timeout occurs");
-                executorService.awaitTermination(timeOut, unit);
+                MoreExecutors.shutdownAndAwaitTermination(executorService, timeOut, unit);
                 log.info("Simple Queue executor service shutdown completed");
-            } catch (InterruptedException e) {
+            } catch (RuntimeException e) {
                 log.error("Error while processing of in-progress tasks, possibly due to timeout while waiting", e);
                 Thread.currentThread().interrupt();
             }

--- a/src/test/java/com/nirmata/workflow/TestNormal.java
+++ b/src/test/java/com/nirmata/workflow/TestNormal.java
@@ -579,6 +579,6 @@ public class TestNormal extends BaseForTests
 
     private void closeWorkflowGracefully(WorkflowManager workflowManager) throws InterruptedException
     {
-        workflowManager.closeGracefully(20);
+        workflowManager.closeGracefully(20, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
Use case: Suppose we have a fleet of workflow task executor instances picking tasks continuously submitted by the leader node. The tasks in nature can be time taking ones. Now someone needs to shutdown instances one by one & tell the workflow manager to not pick any further tasks but finish the ones which are in progress.

Problem: We don't want to block all the instances at a time. The other active instances should pick tasks to avoid full down time and extra check of remaining number of tasks to be picked after stopping the submission of new tasks and before closing all the instances.

Probable solution : We can instruct WorkflowManager to shutdown gracefully which in turn will shutdown the executor service in SimpleQueue class with thread await.