### PR TITLE
fix: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9  # v2
       with:
         java-version: '8'
         distribution: 'adopt'


### PR DESCRIPTION
## Summary

Pins all GitHub Actions `uses:` references to full commit SHAs to prevent supply chain attacks via tag mutation.

### Changes
- `actions/checkout@v2 -> @ee0669bd...`
- `actions/setup-java@v2 -> @91d3aa49...`


### Why

This repo was flagged as **HIGH** risk: unpinned actions triggered by pull requests allow fork-based supply chain attacks.

Tracked in: https://github.com/nirmata/platform-engineering-policies/issues/33
